### PR TITLE
Fix: dialog-basic-info shouldn't display when logout

### DIFF
--- a/app/auth/auth-content.tsx
+++ b/app/auth/auth-content.tsx
@@ -134,7 +134,7 @@ const AuthContent = () => {
     setValue('password', e.target.value)
   }
   return (
-    <div className="w-full h-[calc(100vh-100px)] max-lg:h-[calc(100vh-64px)] flex justify-center bg-secondary max-lg:px-6 mt-16 max-lg:mt-8">
+    <div className="w-full h-[calc(100vh-100px)] max-lg:h-[calc(100vh-64px)] flex justify-center bg-secondary pt-[64px] max-lg:pt-[32px] max-lg:px-6">
       <div className="bg-white rounded-2xl p-12 w-[560px] h-fit">
         <HMText level={7} fontWeight={700} className="mb-4">
           {isSignUp ? '註冊' : '登入'}</HMText>

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -26,7 +26,7 @@ const ProfilePage = () => {
   const [weight, setWeight] = useState('')
   const [latestUpdateWeightDate, setLatestUpdateWeightDate] = useState('')
   useEffect(() => {
-    if(!userInfo?.hasInputBasicInfo ) setIsOpenDefaultInputDialog(true)
+    if(isAuthenticated && !userInfo?.hasInputBasicInfo ) setIsOpenDefaultInputDialog(true)
     else setIsOpenDefaultInputDialog(false)
   },[userInfo?.hasInputBasicInfo, isAuthenticated])
 


### PR DESCRIPTION
將Dialog-basic-info的出現時機設定為已登入且isInputBasicInfo = false的情況(之前沒有已登入的條件，導致登出前將isInputBasic Info設為default的時候，會觸發Dialog出現一秒